### PR TITLE
COOK-1601  Install Emacs without X support by default on Arch linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Requirements
 ## Platform
 
 * Debian/Ubuntu
-* Red Hat/CentOS/Scientific/Fedora
+* Red Hat/CentOS/Scientific/Fedora/Arch
 * FreeBSD
 
 Should work on any platform that has a default provider for the `package` resource and a package named `emacs` avaialble in the default package manager repository.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 case node['platform']
 when "ubuntu","debian"
   default['emacs']['packages'] = ["emacs23-nox"]
-when "redhat","centos","scientific","fedora"
+when "redhat","centos","scientific","fedora","arch"
   default['emacs']['packages'] = ["emacs-nox"]
 when "freebsd"
   default['emacs']['packages'] = ["editors/emacs-nox11"]

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,6 @@ version           "0.8.2"
 
 recipe "emacs", "Installs Emacs"
 
-%w{ ubuntu debian redhat centos scientific fedora freebsd }.each do |os|
+%w{ ubuntu debian redhat centos scientific fedora arch freebsd }.each do |os|
   supports os
 end


### PR DESCRIPTION
Emacs without X support is installed by default on other distros. This commit brings Arch linux inline with that.
