### PR TITLE
Use pkgNG on FreeBSD 10

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 node['emacs']['packages'].each do |pkg|
 
   package pkg do
-    source "ports" if platform?('freebsd')
+    source "ports" if platform?('freebsd') and node.platform_version.to_f < 10.0
   end
 
 end


### PR DESCRIPTION
FreeBSD 10 features pkgNG to deal with package management. Use pkgNG instead of
ports.
