### PR TITLE
use emacs-nox for debian/ubuntu

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,11 +17,9 @@
 #
 
 default['emacs']['packages'] = case node['platform_family']
-                               when 'debian'
-                                 ['emacs24-nox']
                                when 'freebsd'
                                  ['editors/emacs-nox11']
-                               when 'rhel', 'fedora', 'arch'
+                               when 'rhel', 'fedora', 'arch', 'debian'
                                  ['emacs-nox']
                                else
                                  ['emacs']


### PR DESCRIPTION
Latest ubuntus are shipping 25. emacs-nox installs the most up to date nox package on both distros, so 24 on stable debians and 16.04LTS, and 25 on the rest. They're also doing away with the emacs## package naming as of buster and cosmic.