### PR TITLE
feat!: document emacs resource migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@5.0.3
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@6.0.0
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Installs the "emacs" package to install the worlds most flexible, customizable text editor.
 
+## Breaking Change
+
+Upgrading to the next major version of this cookbook is a breaking change. Older versions use
+`recipe[emacs]` / `recipe[emacs::default]` and the `node['emacs']['packages']` attribute. The
+custom-resource migration removes that interface, so wrapper cookbooks, roles, environments, and
+Policyfiles must be updated to use the `emacs_package` resource before you upgrade.
+
+See [migration.md](migration.md) for the required changes.
+
 ## Requirements
 
 ## Platform

--- a/migration.md
+++ b/migration.md
@@ -1,0 +1,40 @@
+# Migration Guide
+
+## Breaking Change
+
+Moving from the legacy recipe-and-attribute interface to the `emacs_package` custom resource is a
+breaking change.
+
+If you are upgrading from an older cookbook release, update every place that still uses
+`recipe[emacs]`, `recipe[emacs::default]`, or `node['emacs']['packages']` before you ship the new
+version. The custom-resource release removes `recipes/default.rb` and `attributes/default.rb`, so
+older wrapper cookbooks and run lists will fail if they are not updated first.
+
+## What operators need to change
+
+Replace this legacy pattern:
+
+```ruby
+node.default['emacs']['packages'] = %w(emacs-nox)
+include_recipe 'emacs::default'
+```
+
+With the custom resource:
+
+```ruby
+emacs_package 'default' do
+  packages %w(emacs-nox)
+end
+```
+
+If you previously relied on the cookbook defaults, the minimal replacement is:
+
+```ruby
+emacs_package 'default'
+```
+
+## Upgrade checklist
+
+* Remove `recipe[emacs]` or `recipe[emacs::default]` from run lists, wrapper cookbooks, and test cookbooks.
+* Stop setting `node['emacs']['packages']`; pass package names with the `packages` property instead.
+* Verify any platform-specific package overrides are declared explicitly in the resource block before upgrading production nodes.


### PR DESCRIPTION
## Summary
- add an explicit breaking-change warning to the README for operators upgrading from recipe and attribute usage
- add a migration guide that shows how to replace recipe[emacs] and node['emacs']['packages'] with emacs_package

## Release Please
- commit uses feat! and a BREAKING CHANGE footer so Release Please treats this as a major change